### PR TITLE
Use docker-compose to orchestrate containers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.yaml]
+[*.yaml,*.yml]
 indent_size = 2
 
 [*.md]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  reportbook:
+    build:
+      context: .
+      dockerfile: Dockerfile.debug
+    ports:
+      - "80:80"
+    environment:
+      - APPLICATION_ENV=dev
+      - MONGO_HOST=mongo
+      - MAILGUN_DOMAIN
+      - MAILGUN_KEY
+    extra_hosts:
+      - "docker_host:${DOCKER_HOST_IP}"
+    volumes:
+      - .:/var/www
+  mongo:
+    image: "mongo"
+    ports:
+      - "27017:27017"
+    volumes:
+      - reportbook-data:/data/db
+      - ./scripts:/scripts
+    command: --auth
+volumes:
+  reportbook-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "80:80"
     environment:
-      - APPLICATION_ENV=dev
+      - APPLICATION_ENV
       - MONGO_HOST=mongo
       - MAILGUN_DOMAIN
       - MAILGUN_KEY
@@ -15,6 +15,8 @@ services:
       - "docker_host:${DOCKER_HOST_IP}"
     volumes:
       - .:/var/www
+    links:
+      - mongo
   mongo:
     image: "mongo"
     ports:

--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -1,18 +1,11 @@
 #!/bin/sh
 
-APPLICATION_ENV=dev
+export APPLICATION_ENV=dev
+export DOCKER_HOST_IP=$(docker-machine inspect --format '{{ .Driver.HostOnlyCIDR}}' | awk -F/ '{print $1}')
 
 if [ -e .env ]
 then
     source .env
 fi
 
-docker run -it --rm \
-    -p 80:80 \
-    -e APPLICATION_ENV='dev' \
-    -e MONGO_HOST=$(docker-machine ip) \
-    -e MAILGUN_DOMAIN=$MAILGUN_DOMAIN \
-    -e MAILGUN_KEY=$MAILGUN_KEY \
-    -v $(PWD)/:/var/www/ \
-    --add-host="docker_host:$(docker-machine inspect --format '{{ .Driver.HostOnlyCIDR}}' | awk -F/ '{print $1}')" \
-    jimdo/reportbook:debug
+docker-compose up

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -10,11 +10,6 @@ fi
 
 export APPLICATION_ENV=test
 
-docker run -it --rm \
-    -e APPLICATION_ENV=$APPLICATION_ENV \
-    -e MONGO_HOST=$MONGO_HOST \
-    -e MYSQL_HOST=$MYSQL_HOST \
-    -v $(PWD)/:/var/www/ \
-    --add-host="docker_host:$(docker-machine inspect --format '{{ .Driver.HostOnlyCIDR}}' | awk -F/ '{print $1}')" \
-    jimdo/reportbook:debug \
-    scripts/phpunit
+export DOCKER_HOST_IP=$(docker-machine inspect --format '{{ .Driver.HostOnlyCIDR}}' | awk -F/ '{print $1}')
+
+docker-compose run reportbook scripts/phpunit

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,5 +1,5 @@
 [xdebug]
-xdebug.remote_enable=On
-xdebug.remote_autostart=Off
+xdebug.remote_enable=Off
+xdebug.remote_autostart=On
 xdebug.remote_connect_back=Off
 xdebug.remote_host=docker_host


### PR DESCRIPTION
In order to have one central configuration file for all docker containers used for the project we use docker-composer.yml file now.