### PR TITLE
Use bundled aws CLI instead of packaged one

### DIFF
--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -6,9 +6,15 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927 && \
     echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 
 RUN apt-get update && apt-get install -y \
-    awscli \
+    python \
+    unzip \
+    curl \
     mongodb-org-shell \
     mongodb-org-tools
+
+RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+RUN unzip awscli-bundle.zip
+RUN ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 
 WORKDIR /backup
 


### PR DESCRIPTION
Right now the packaged version is broken in current Ubuntu releases: https://github.com/aws/aws-cli/issues/2403