### PR TITLE
Remove docker-machine ip 

### DIFF
--- a/scripts/run-testsuite.sh
+++ b/scripts/run-testsuite.sh
@@ -1,20 +1,20 @@
 #!/bin/sh
 
 if [ -z ${MONGO_HOST+x} ]; then
-  export MONGO_HOST=$(docker-machine ip)
+  export MONGO_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' reportbook_reportbook_1)
 fi
 
 if [ -z ${MYSQL_HOST+x} ]; then
-  export MYSQL_HOST=$(docker-machine ip)
+  export MYSQL_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' reportbook_reportbook_1)
 fi
 
 if [ -z ${SELENIUM_IP+x} ]; then
-  export SELENIUM_IP=$(docker-machine ip)
+  export SELENIUM_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' reportbook_reportbook_1)
 fi
 
 export APPLICATION_ENV=test
 
-export REPORTBOOK_IP=$(docker-machine ip)
+export REPORTBOOK_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' reportbook_reportbook_1)
 
 export DOCKER_HOST_IP=$(docker-machine inspect --format '{{ .Driver.HostOnlyCIDR}}' | awk -F/ '{print $1}')
 


### PR DESCRIPTION
We have to remove `docker-machine ip` because we now use `Docker for Mac`.
This will also fix the selenium tests.